### PR TITLE
Fix build for Java 1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,18 @@
         </dependency>
     </dependencies>
 
+    <profiles>
+      <profile>
+        <id>doclint-java8-disable</id>
+        <activation>
+          <jdk>[1.8,)</jdk>
+        </activation>
+        <properties>
+          <javadoc.opts>-Xdoclint:none</javadoc.opts>
+        </properties>
+      </profile>
+    </profiles>
+
     <build>
         <plugins>
 
@@ -137,6 +149,9 @@
                         <goals>
                             <goal>jar</goal>
                         </goals>
+                        <configuration>
+                           <additionalparam>${javadoc.opts}</additionalparam>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
Java 1.8 is a little stricter with javadocs, causing the maven-javadoc-pluging to fail.
This patch disables DocLint.